### PR TITLE
Stm8 interrupt mode correction

### DIFF
--- a/cores/arduino/stm8/interrupt.c
+++ b/cores/arduino/stm8/interrupt.c
@@ -1,40 +1,40 @@
 /**
-  ******************************************************************************
-  * @file    interrupt.c
-  * @author  WI6LABS
-  * @version V1.0.0
-  * @date    16-September-2016
-  * @brief   provide an interface to enable/disable interruptions
-  *
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+******************************************************************************
+* @file    interrupt.c
+* @author  WI6LABS
+* @version V1.0.0
+* @date    16-September-2016
+* @brief   provide an interface to enable/disable interruptions
+*
+******************************************************************************
+* @attention
+*
+* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*   1. Redistributions of source code must retain the above copyright notice,
+*      this list of conditions and the following disclaimer.
+*   2. Redistributions in binary form must reproduce the above copyright notice,
+*      this list of conditions and the following disclaimer in the documentation
+*      and/or other materials provided with the distribution.
+*   3. Neither the name of STMicroelectronics nor the names of its contributors
+*      may be used to endorse or promote products derived from this software
+*      without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************
+*/
 
 #include "stm8_def.h"
 #include "interrupt.h"
@@ -43,240 +43,239 @@
 extern "C"
 {
 #endif
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /** @addtogroup stm8sxx_System_Private_TypesDefinitions
-  * @{
-  */
+/** @addtogroup stm8sxx_System_Private_TypesDefinitions
+* @{
+*/
 
-  typedef struct
-  {
-    EXTI_Port_TypeDef EXTI_port;
-    GPIO_Pin_TypeDef pin;
+typedef struct
+{
+  EXTI_Port_TypeDef EXTI_port;
+  GPIO_Pin_TypeDef pin;
 #if defined(STM8Sxx)
-    EXTI_Sensitivity_TypeDef EXTI_mode;
+  EXTI_Sensitivity_TypeDef EXTI_mode;
 #elif defined(STM8Lxx)
   GPIO_TypeDef *port_IT;
   EXTI_Pin_TypeDef EXTI_pin;
   EXTI_Trigger_TypeDef EXTI_mode;
 #endif
-    void (*callback)(void);
-  } gpio_irq_conf_str;
+  void (*callback)(void);
+} gpio_irq_conf_str;
 
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /** @addtogroup stm8sxx_System_Private_Defines
-  * @{
-  */
+/** @addtogroup stm8sxx_System_Private_Defines
+* @{
+*/
 
 #define NB_EXTI ((uint8_t)16)
 
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /** @addtogroup stm8sxx_System_Private_Macros
-  * @{
-  */
+/** @addtogroup stm8sxx_System_Private_Macros
+* @{
+*/
 
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /** @addtogroup stm8sxx_System_Private_Variables
-  * @{
-  */
-  static gpio_irq_conf_str gpio_irq_conf[NB_EXTI];
+/** @addtogroup stm8sxx_System_Private_Variables
+* @{
+*/
+static gpio_irq_conf_str gpio_irq_conf[NB_EXTI];
 
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /** @addtogroup stm8sxx_System_Private_FunctionPrototypes
-  * @{
-  */
+/** @addtogroup stm8sxx_System_Private_FunctionPrototypes
+* @{
+*/
 
-  static uint8_t get_pin_id(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin, uint8_t init);
+static uint8_t get_pin_id(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin, uint8_t init);
 
-  /**
-  * @}
-  */
+/**
+* @}
+*/
 
-  /**
-  * @brief  This function returns the pin ID function of the PIN definition
-  * @param  port : one of the gpio port
-  * @param  pin : one of the gpio pin
-  * @retval None
-  */
-  static uint8_t get_pin_id(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin, uint8_t init)
-  {
-    uint8_t id = 0xFF;
-    uint8_t i = 0;
-    EXTI_Port_TypeDef EXTI_port;
+/**
+* @brief  This function returns the pin ID function of the PIN definition
+* @param  port : one of the gpio port
+* @param  pin : one of the gpio pin
+* @retval None
+*/
+static uint8_t get_pin_id(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin, uint8_t init)
+{
+  uint8_t id = 0xFF;
+  uint8_t i = 0;
+  EXTI_Port_TypeDef EXTI_port;
 
 #if defined(STM8Sxx)
-    if (port == GPIOA)
-    {
-      EXTI_port = EXTI_PORT_GPIOA;
-    }
-    else if (port == GPIOB)
-    {
-      EXTI_port = EXTI_PORT_GPIOB;
-    }
-    else if (port == GPIOC)
-    {
-      EXTI_port = EXTI_PORT_GPIOC;
-    }
-    else if (port == GPIOD)
-    {
-      EXTI_port = EXTI_PORT_GPIOD;
-    }
-    else if (port == GPIOE)
-    {
-      EXTI_port = EXTI_PORT_GPIOE;
-    }
-    else
-    {
-      return id;
-    }
+  if (port == GPIOA)
+  {
+    EXTI_port = EXTI_PORT_GPIOA;
+  }
+  else if (port == GPIOB)
+  {
+    EXTI_port = EXTI_PORT_GPIOB;
+  }
+  else if (port == GPIOC)
+  {
+    EXTI_port = EXTI_PORT_GPIOC;
+  }
+  else if (port == GPIOD)
+  {
+    EXTI_port = EXTI_PORT_GPIOD;
+  }
+  else if (port == GPIOE)
+  {
+    EXTI_port = EXTI_PORT_GPIOE;
+  }
+  else
+  {
+    return id;
+  }
 #elif defined(STM8Lxx)
-    EXTI_Pin_TypeDef EXTI_pin;
+  EXTI_Pin_TypeDef EXTI_pin;
 
-    if (port == GPIOB)
-    {
-      EXTI_port = EXTI_Port_B;
-    }
-    else if (port == GPIOD)
-    {
-      EXTI_port = EXTI_Port_D;
-    }
-    else if (port == GPIOE)
-    {
-      EXTI_port = EXTI_Port_E;
-    }
-    else if (port == GPIOF)
-    {
-      EXTI_port = EXTI_Port_F;
-    }
-    else if (port == GPIOG)
-    {
-      EXTI_port = EXTI_Port_G;
-    }
-    else if (port == GPIOH)
-    {
-      EXTI_port = EXTI_Port_H;
-    }
-    else
-    {
-      return id;
-    }
-
-    if (pin == GPIO_Pin_0)
-    {
-      EXTI_pin = EXTI_Pin_0;
-    }
-    else if (pin == GPIO_Pin_1)
-    {
-      EXTI_pin = EXTI_Pin_1;
-    }
-    else if (pin == GPIO_Pin_2)
-    {
-      EXTI_pin = EXTI_Pin_2;
-    }
-    else if (pin == GPIO_Pin_3)
-    {
-      EXTI_pin = EXTI_Pin_3;
-    }
-    else if (pin == GPIO_Pin_4)
-    {
-      EXTI_pin = EXTI_Pin_4;
-    }
-    else if (pin == GPIO_Pin_5)
-    {
-      EXTI_pin = EXTI_Pin_5;
-    }
-    else if (pin == GPIO_Pin_6)
-    {
-      EXTI_pin = EXTI_Pin_6;
-    }
-    else if (pin == GPIO_Pin_7)
-    {
-      EXTI_pin = EXTI_Pin_7;
-    }
-    else
-    {
-      return id;
-    }
-
-#endif
-    for (id = 0; id < NB_EXTI; id++)
-    {
-      if ((gpio_irq_conf[id].EXTI_port == EXTI_port) && (gpio_irq_conf[id].pin == pin))
-      {
-        id = i;
-        break;
-      }
-      else if (init == 1)
-      {
-          gpio_irq_conf[id].EXTI_port = EXTI_port;
-          gpio_irq_conf[id].pin = pin;
-          gpio_irq_conf[id].callback = 0;
-#ifdef STM8Lxx
-          gpio_irq_conf[id].port_IT = port;
-          gpio_irq_conf[id].EXTI_pin = EXTI_pin;
-#endif
-          id = i;
-        }
-        break;
-      }
-
-
+  if (port == GPIOB)
+  {
+    EXTI_port = EXTI_Port_B;
+  }
+  else if (port == GPIOD)
+  {
+    EXTI_port = EXTI_Port_D;
+  }
+  else if (port == GPIOE)
+  {
+    EXTI_port = EXTI_Port_E;
+  }
+  else if (port == GPIOF)
+  {
+    EXTI_port = EXTI_Port_F;
+  }
+  else if (port == GPIOG)
+  {
+    EXTI_port = EXTI_Port_G;
+  }
+  else if (port == GPIOH)
+  {
+    EXTI_port = EXTI_Port_H;
+  }
+  else
+  {
     return id;
   }
 
-  /**
-  * @brief  This function enable the interruption on the selected port/pin
-  * @param  port : one of the gpio port
-  * @param  pin : one of the gpio pin
-  **@param  callback : callback to call when the interrupt falls
-  * @param  mode : one of the supported interrupt mode defined in stm32_hal_gpio
-  * @retval None
-  */
+  if (pin == GPIO_Pin_0)
+  {
+    EXTI_pin = EXTI_Pin_0;
+  }
+  else if (pin == GPIO_Pin_1)
+  {
+    EXTI_pin = EXTI_Pin_1;
+  }
+  else if (pin == GPIO_Pin_2)
+  {
+    EXTI_pin = EXTI_Pin_2;
+  }
+  else if (pin == GPIO_Pin_3)
+  {
+    EXTI_pin = EXTI_Pin_3;
+  }
+  else if (pin == GPIO_Pin_4)
+  {
+    EXTI_pin = EXTI_Pin_4;
+  }
+  else if (pin == GPIO_Pin_5)
+  {
+    EXTI_pin = EXTI_Pin_5;
+  }
+  else if (pin == GPIO_Pin_6)
+  {
+    EXTI_pin = EXTI_Pin_6;
+  }
+  else if (pin == GPIO_Pin_7)
+  {
+    EXTI_pin = EXTI_Pin_7;
+  }
+  else
+  {
+    return id;
+  }
+
+#endif
+  for (id = 0; id < NB_EXTI; id++)
+  {
+    if ((gpio_irq_conf[id].EXTI_port == EXTI_port) && (gpio_irq_conf[id].pin == pin))
+    {
+      id = i;
+      break;
+    }
+    else if (init == 1)
+    {
+      gpio_irq_conf[id].EXTI_port = EXTI_port;
+      gpio_irq_conf[id].pin = pin;
+      gpio_irq_conf[id].callback = 0;
+#ifdef STM8Lxx
+      gpio_irq_conf[id].port_IT = port;
+      gpio_irq_conf[id].EXTI_pin = EXTI_pin;
+#endif
+        id = i;
+    }
+      break;
+  }
+
+  return id;
+}
+
+/**
+* @brief  This function enable the interruption on the selected port/pin
+* @param  port : one of the gpio port
+* @param  pin : one of the gpio pin
+**@param  callback : callback to call when the interrupt falls
+* @param  mode : one of the supported interrupt mode defined in stm32_hal_gpio
+* @retval None
+*/
 
 #if defined(STM8Sxx)
-  void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
-                             void (*callback)(void),
-                             EXTI_Sensitivity_TypeDef EXTI_mode)
-#elif defined(STM8Lxx)
 void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
                            void (*callback)(void),
-                             EXTI_Trigger_TypeDef EXTI_mode)
+                           EXTI_Sensitivity_TypeDef EXTI_mode)
+#elif defined(STM8Lxx)
+void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
+                         void (*callback)(void),
+                           EXTI_Trigger_TypeDef EXTI_mode)
 #endif
+{
+  GPIO_Mode_TypeDef GPIO_mode;
+
+  uint8_t id = get_pin_id(port, pin, 1);
+  if (id == NC)
   {
-    GPIO_Mode_TypeDef GPIO_mode;
+    return;
+  }
 
-    uint8_t id = get_pin_id(port, pin, 1);
-    if (id == NC)
-    {
-      return;
-    }
-
-    gpio_irq_conf[id].callback = callback;
-    gpio_irq_conf[id].EXTI_mode = EXTI_mode;
+  gpio_irq_conf[id].callback = callback;
+  gpio_irq_conf[id].EXTI_mode = EXTI_mode;
 
 #if defined(STM8Sxx)
-    if ((port->CR1 & pin) == pin)
-    {
-      GPIO_mode = GPIO_MODE_IN_PU_IT;
-    }
-    else
-    {
-      GPIO_mode = GPIO_MODE_IN_FL_IT;
-    }
+  if ((port->CR1 & pin) == pin)
+  {
+    GPIO_mode = GPIO_MODE_IN_PU_IT;
+  }
+  else
+  {
+    GPIO_mode = GPIO_MODE_IN_FL_IT;
+  }
 #endif
 #if defined(STM8Lxx)
   if ((port->CR1 & pin) == pin)
@@ -289,52 +288,52 @@ void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
   }
 #endif
 
-    // Enable and set EXTI Interrupt
-    disableInterrupts();
-    GPIO_Init(port, pin, GPIO_mode);
+  // Enable and set EXTI Interrupt
+  disableInterrupts();
+  GPIO_Init(port, pin, GPIO_mode);
 #if defined(STM8Sxx)
-    EXTI_SetExtIntSensitivity(gpio_irq_conf[id].EXTI_port, EXTI_mode);
+  EXTI_SetExtIntSensitivity(gpio_irq_conf[id].EXTI_port, EXTI_mode);
 #elif defined(STM8Lxx)
-    EXTI_SetPortSensitivity(gpio_irq_conf[id].EXTI_port, EXTI_mode);
+  EXTI_SetPortSensitivity(gpio_irq_conf[id].EXTI_port, EXTI_mode);
 #endif
 
-    enableInterrupts();
+  enableInterrupts();
+}
+
+/**
+* @brief  This function disable the interruption on the selected port/pin
+* @param  port : one of the gpio port
+* @param  pin : one of the gpio pin
+* @retval None
+*/
+void stm8_interrupt_disable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin)
+{
+  GPIO_Mode_TypeDef GPIO_mode = (GPIO_Mode_TypeDef)0;
+
+  uint8_t id = get_pin_id(port, pin, 0);
+  if (id == NC)
+  {
+    return;
   }
 
-  /**
-  * @brief  This function disable the interruption on the selected port/pin
-  * @param  port : one of the gpio port
-  * @param  pin : one of the gpio pin
-  * @retval None
-  */
-  void stm8_interrupt_disable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin)
-  {
-    GPIO_Mode_TypeDef GPIO_mode = (GPIO_Mode_TypeDef)0;
-
-    uint8_t id = get_pin_id(port, pin, 0);
-    if (id == NC)
-    {
-      return;
-    }
-
-    gpio_irq_conf[id].EXTI_port = (EXTI_Port_TypeDef)0;
-    gpio_irq_conf[id].pin = (GPIO_Pin_TypeDef)0;
+  gpio_irq_conf[id].EXTI_port = (EXTI_Port_TypeDef)0;
+  gpio_irq_conf[id].pin = (GPIO_Pin_TypeDef)0;
 #if defined(STM8Sxx)
-    gpio_irq_conf[id].EXTI_mode = (EXTI_Sensitivity_TypeDef)0;
+  gpio_irq_conf[id].EXTI_mode = (EXTI_Sensitivity_TypeDef)0;
 #elif defined(STM8Lxx)
   gpio_irq_conf[id].EXTI_mode = (EXTI_Trigger_TypeDef)0;
 #endif
-    gpio_irq_conf[id].callback = 0;
+  gpio_irq_conf[id].callback = 0;
 
 #if defined(STM8Sxx)
-    if ((port->CR1 & pin) == pin)
-    {
-      GPIO_mode = GPIO_MODE_IN_PU_NO_IT;
-    }
-    else
-    {
-      GPIO_mode = GPIO_MODE_IN_FL_NO_IT;
-    }
+  if ((port->CR1 & pin) == pin)
+  {
+    GPIO_mode = GPIO_MODE_IN_PU_NO_IT;
+  }
+  else
+  {
+    GPIO_mode = GPIO_MODE_IN_FL_NO_IT;
+  }
 #elif defined(STM8Lxx)
   if ((port->CR1 & pin) == pin)
   {
@@ -345,87 +344,87 @@ void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
     GPIO_mode = GPIO_Mode_In_FL_No_IT;
   }
 #endif
-    GPIO_Init(port, pin, GPIO_mode);
-  }
+  GPIO_Init(port, pin, GPIO_mode);
+}
 
-  /**
-  * @brief This function his called by EXTI interrupt
-  * @param  EXTI_port : EXTI_Port_TypeDef
-  * @retval None
-  */
+/**
+* @brief This function his called by EXTI interrupt
+* @param  EXTI_port : EXTI_Port_TypeDef
+* @retval None
+*/
 #if defined(STM8Sxx)
-  void GPIO_EXTI_Callback(EXTI_Port_TypeDef EXTI_port)
-  {
+void GPIO_EXTI_Callback(EXTI_Port_TypeDef EXTI_port)
+{
 #endif
 #if defined(STM8Lxx)
-  void GPIO_EXTI_Callback(EXTI_IT_TypeDef EXTI_port_pin)
-  {
+void GPIO_EXTI_Callback(EXTI_IT_TypeDef EXTI_port_pin)
+{
 #endif
-    GPIO_TypeDef *port;
-    GPIO_Pin_TypeDef pin;
-    BitStatus status = RESET;
-    uint8_t i = 0;
+  GPIO_TypeDef *port;
+  GPIO_Pin_TypeDef pin;
+  BitStatus status = RESET;
+  uint8_t i = 0;
 #if defined(STM8Sxx)
-    if (EXTI_port == EXTI_PORT_GPIOA)
-    {
-      port = GPIOA;
-    }
-    else if (EXTI_port == EXTI_PORT_GPIOB)
-    {
-      port = GPIOB;
-    }
-    else if (EXTI_port == EXTI_PORT_GPIOC)
-    {
-      port = GPIOC;
-    }
-    else if (EXTI_port == EXTI_PORT_GPIOD)
-    {
-      port = GPIOD;
-    }
-    else if (EXTI_port == EXTI_PORT_GPIOE)
-    {
-      port = GPIOE;
-    }
-    else
-    {
-      return;
-    }
+  if (EXTI_port == EXTI_PORT_GPIOA)
+  {
+    port = GPIOA;
+  }
+  else if (EXTI_port == EXTI_PORT_GPIOB)
+  {
+    port = GPIOB;
+  }
+  else if (EXTI_port == EXTI_PORT_GPIOC)
+  {
+    port = GPIOC;
+  }
+  else if (EXTI_port == EXTI_PORT_GPIOD)
+  {
+    port = GPIOD;
+  }
+  else if (EXTI_port == EXTI_PORT_GPIOE)
+  {
+    port = GPIOE;
+  }
+  else
+  {
+    return;
+  }
 
-    for (i = 0; i < NB_EXTI; i++)
+  for (i = 0; i < NB_EXTI; i++)
+  {
+    if (gpio_irq_conf[i].EXTI_port == EXTI_port)
     {
-      if (gpio_irq_conf[i].EXTI_port == EXTI_port)
+      switch (gpio_irq_conf[i].EXTI_mode)
       {
-        switch (gpio_irq_conf[i].EXTI_mode)
+      case EXTI_SENSITIVITY_FALL_LOW:
+      case EXTI_SENSITIVITY_FALL_ONLY:
+        if (GPIO_ReadInputPin(port, gpio_irq_conf[i].pin) == RESET)
         {
-        case EXTI_SENSITIVITY_FALL_LOW:
-        case EXTI_SENSITIVITY_FALL_ONLY:
-          if (GPIO_ReadInputPin(port, gpio_irq_conf[i].pin) == RESET)
-          {
-            status = SET;
-          }
-          break;
-
-        case EXTI_SENSITIVITY_RISE_ONLY:
-          if (GPIO_ReadInputPin(port, gpio_irq_conf[i].pin) != RESET)
-          {
-            status = SET;
-          }
-          break;
-
-        case EXTI_SENSITIVITY_RISE_FALL:
           status = SET;
-          break;
-
-        default:
-          break;
         }
+        break;
 
-        if ((gpio_irq_conf[i].callback != 0) && (status == SET))
+      case EXTI_SENSITIVITY_RISE_ONLY:
+        if (GPIO_ReadInputPin(port, gpio_irq_conf[i].pin) != RESET)
         {
-          gpio_irq_conf[i].callback();
+          status = SET;
         }
+        break;
+
+      case EXTI_SENSITIVITY_RISE_FALL:
+        status = SET;
+        break;
+
+      default:
+        break;
+      }
+
+      if ((gpio_irq_conf[i].callback != 0) && (status == SET))
+      {
+        gpio_irq_conf[i].callback();
       }
     }
+  }
 #endif
 #if defined(STM8Lxx)
   EXTI_Port_TypeDef EXTI_port;
@@ -542,19 +541,19 @@ void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
     }
   }
 #endif
-  }
+}
 
 /**
-  * @}
-  */
+* @}
+*/
 
 /**
-  * @}
-  */
+* @}
+*/
 
 /**
-  * @}
-  */
+* @}
+*/
 #ifdef __cplusplus
 }
 #endif

--- a/cores/arduino/stm8/interrupt.h
+++ b/cores/arduino/stm8/interrupt.h
@@ -1,39 +1,39 @@
 /**
-  ******************************************************************************
-  * @file    interrup.h
-  * @author  WI6LABS
-  * @version V1.0.0
-  * @date    16-September-2016
-  * @brief   Header for interrupt module
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+******************************************************************************
+* @file    interrup.h
+* @author  WI6LABS
+* @version V1.0.0
+* @date    16-September-2016
+* @brief   Header for interrupt module
+******************************************************************************
+* @attention
+*
+* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*   1. Redistributions of source code must retain the above copyright notice,
+*      this list of conditions and the following disclaimer.
+*   2. Redistributions in binary form must reproduce the above copyright notice,
+*      this list of conditions and the following disclaimer in the documentation
+*      and/or other materials provided with the distribution.
+*   3. Neither the name of STMicroelectronics nor the names of its contributors
+*      may be used to endorse or promote products derived from this software
+*      without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************
+*/
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __INTERRUPT_H
@@ -53,14 +53,14 @@ extern "C"
 /* Exported functions ------------------------------------------------------- */
 #if defined(STM8Sxx)
   void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
-                             void (*callback)(void),
-                             EXTI_Sensitivity_TypeDef mode);
+                           void (*callback)(void),
+                           EXTI_Sensitivity_TypeDef mode);
   void GPIO_EXTI_Callback(EXTI_Port_TypeDef EXTI_port);
 #endif
 #if defined(STM8Lxx)
   void stm8_interrupt_enable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin,
-                           void (*callback)(void),
-                           EXTI_Trigger_TypeDef mode);
+                         void (*callback)(void),
+                         EXTI_Trigger_TypeDef mode);
   void GPIO_EXTI_Callback(EXTI_IT_TypeDef EXTI_port_pin);
 #endif
   void stm8_interrupt_disable(GPIO_TypeDef *port, GPIO_Pin_TypeDef pin);


### PR DESCRIPTION
This pull request provides a correction to support multiple interrupt sources on STM8S and STM8L.

On STM8S, PG0 (D4) cannot be used to test the interrupts. PG IO block doesn't support EXTI. You can use D0 instead for example.

If you are running the test_io exemple, carefull to check the available IOs and to reduce the clock speed of the example from 1000 to 800.